### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-python manage.py migrate --no-input
-python manage.py collectstatic --no-input
+python manage.py migrate && python manage.py collectstatic &&
 
 gunicorn django_project.wsgi:application --bind 0.0.0.0:8000
 


### PR DESCRIPTION
I removed --no-input  for the error( django_gunicorn_1  | manage.py migrate: error: unrecognized arguments: --no-input)
and the "&&" is a solution for error ( django_gunicorn_1  | Unknown command: 'migrate\r'. Did you mean migrate? )